### PR TITLE
fix(collector): 已收录插件的作者自述不再丢失（候选合并并入 + issue 关闭后沿用）

### DIFF
--- a/collector/src/index.ts
+++ b/collector/src/index.ts
@@ -217,6 +217,11 @@ async function main() {
           ...new Set([...(existing.issueNumbers ?? []), ...meta.issueNumbers]),
         ];
       }
+      // issue 里的「作者自述」同样要并入：候选多由 topic 扫描先创建，
+      // 此前该字段只在首次创建时写入 → 已收录插件的自述永远进不来
+      if (meta?.introByAuthor && !existing.introByAuthor) {
+        existing.introByAuthor = meta.introByAuthor;
+      }
       return;
     }
     candidates.set(key, {
@@ -249,6 +254,8 @@ async function main() {
   console.log("[2/5] 特征检测 + 元数据抓取（并发 10，带缓存）...");
   const detected: Detected[] = [];
   const rejected: { fullName: string; reason: string }[] = [];
+  // 上次收录记录：B2 延续性 + 作者自述持久化（见下）
+  const prevPlugins = loadPreviousPlugins();
 
   const detectOne = async (candidate: Candidate) => {
     try {
@@ -466,7 +473,11 @@ async function main() {
         createdAt: repo!.created_at,
         updatedAt: repo!.updated_at,
         readmeSummary,
-        introByAuthor: candidate.introByAuthor,
+        // 作者自述：issue 是唯一来源，且采集只读 open issue——收录确认后 issue 会被自动关闭，
+        // 因此关闭后沿用上次抓到的自述，否则自述会在次日随 issue 关闭一起消失
+        introByAuthor:
+          candidate.introByAuthor ??
+          prevPlugins.get(candidate.fullName.toLowerCase())?.introByAuthor,
         submissionIssue: candidate.issueNumbers?.[0],
         install: {
           method: installMethod,
@@ -539,7 +550,6 @@ async function main() {
   // [B2] 已收录延续性：上次收录但本次未扫描到的仓库补回（防边界抖动消失；404 确认真删除才移除）
   // 优化：检测缓存证明仓库存在且 pushedAt 未变的直接补回（零 API）；只有缓存缺失/变化的才逐个调 repos API
   // ——避免每次对上干个 miss 逐个请求撞限流（曾让 cron 从 10 分钟涨到 2 小时）
-  const prevPlugins = loadPreviousPlugins();
   const currentIds = new Set(detected.map((d) => d.plugin.id.toLowerCase()));
   const missing = [...prevPlugins.keys()].filter((id) => !currentIds.has(id));
   let restored = 0;

--- a/collector/src/sources/issues.ts
+++ b/collector/src/sources/issues.ts
@@ -63,13 +63,16 @@ export interface SubmissionMeta {
   introByAuthor?: string;
 }
 
+/**
+ * 提交/修正 issue 的标题前缀（README「已收录插件可提交 `[数据修正]` issue 补写作者自述」，
+ * CONTRIBUTING 同款说明）——`[数据修正]` 必须一并识别，否则补写的自述永远不会被读到
+ */
+export const SUBMISSION_TITLE_RE =
+  /^\[(提交插件|提交工具|数据修正|submit|plugin submission)\]/i;
+
 /** 读取本仓库所有 open 的提交插件 issue：返回 fullName(lower) → 元数据（issue 号 + 作者自述） */
 export async function fetchSubmissionRepos(): Promise<Map<string, SubmissionMeta>> {
-  return fetchSubmissionReposBy(
-    /^\[(提交插件|提交工具|submit|plugin submission)\]/i,
-    "submission",
-    "issues:submission"
-  );
+  return fetchSubmissionReposBy(SUBMISSION_TITLE_RE, "submission", "issues:submission");
 }
 
 /** 读取本仓库所有 open 的提交整合包 issue（[提交整合包] 标题）→ fullName(lower) → issue 号列表 */

--- a/collector/test/issues.test.ts
+++ b/collector/test/issues.test.ts
@@ -1,5 +1,28 @@
 import { describe, expect, it } from "vitest";
-import { extractRepoFromText, extractIntroByAuthor } from "../src/sources/issues.js";
+import {
+  extractRepoFromText,
+  extractIntroByAuthor,
+  SUBMISSION_TITLE_RE,
+} from "../src/sources/issues.js";
+
+describe("SUBMISSION_TITLE_RE", () => {
+  it("识别提交类标题", () => {
+    expect(SUBMISSION_TITLE_RE.test("[提交插件] dsh-proxy")).toBe(true);
+    expect(SUBMISSION_TITLE_RE.test("[提交工具] 某工具")).toBe(true);
+    expect(SUBMISSION_TITLE_RE.test("[submit] foo")).toBe(true);
+  });
+
+  it("识别 [数据修正] 标题（已收录插件补写作者自述的官方写法）", () => {
+    expect(SUBMISSION_TITLE_RE.test("[数据修正] dsh-quote-followup 补写作者自述")).toBe(true);
+    expect(SUBMISSION_TITLE_RE.test("[数据修正] 安装命令有误")).toBe(true);
+  });
+
+  it("不误伤普通 issue 标题", () => {
+    expect(SUBMISSION_TITLE_RE.test("插件安装失败")).toBe(false);
+    expect(SUBMISSION_TITLE_RE.test("[提问] 如何安装")).toBe(false);
+    expect(SUBMISSION_TITLE_RE.test("提交插件但没加方括号")).toBe(false);
+  });
+});
 
 describe("extractRepoFromText", () => {
   it("从 issue 正文提取仓库地址", () => {


### PR DESCRIPTION
## 问题

已收录插件用 `[数据修正]` issue 补写「作者自述」（README 第 224 行 / CONTRIBUTING 推荐的写法）永远进不了市场。两个独立原因：

1. **标题不识别** —— `fetchSubmissionRepos` 只认 `[提交插件]/[提交工具]/[submit]/[plugin submission]`；`[数据修正]` 若未打 `submission` label，整条 issue 被跳过。
2. **合并丢字段** —— `addCandidate` 的合并分支只并入 `sources/repo/issueNumbers`，不并入 `introByAuthor`。候选通常由 topic 扫描先创建，而该字段只在首次创建时写入，于是自述被静默丢弃。

佐证：

- 市场 `data/plugins.json` 里 10 个有 `introByAuthor` 的插件，`sources` **全部**是 `['issue-submission']`，没有一个含 `topic`；
- `tr1v3r/dsh-proxy` 的 #134 是标准模板 + 规范自述、提的时候还是 open，`introByAuthor` 仍为 `null`。

另外：采集只读 **open** issue，而收录确认后 `scripts/reply-issues.mjs` 会自动关闭该 issue，自述会随关闭在次日消失。

## 改动

- `collector/src/sources/issues.ts`：抽出 `SUBMISSION_TITLE_RE` 并加入 `数据修正`（与文档口径一致）。
- `collector/src/index.ts`：
  - `addCandidate` 合并分支并入 `introByAuthor`；
  - 插件构建时 `introByAuthor: candidate.introByAuthor ?? 上次收录记录的值`（`loadPreviousPlugins()` 提前到检测之前，B2 复用同一实例，不多读文件）。
- `collector/test/issues.test.ts`：新增 3 例标题识别测试。

## 验证

```bash
npm test -w collector                          # 5 files / 64 passed（新增 3 例）
npx tsc --noEmit -p collector/tsconfig.json    # 通过
```

## 影响与取舍

- 已收录插件补写自述的路径恢复可用（`[数据修正]` 标题或 `submission` label 均可）。
- issue 关闭后自述不再消失。
- 取舍：沿用旧值意味着作者**无法删除**已收录的自述。如果需要清空能力，可以约定一个显式写法（例如 `作者自述：无`），看你想怎么定。
- 提示：`[数据修正]` 进入提交队列后，`reply-issues.mjs` 会评论「已收录」并关闭该 issue，文案对数据修正类略不贴切；如需区分可在 `reply-issues.mjs` 里按标题分流，我这次没动它以免扩大改动面。
