### PR TITLE
fix: recognize official DSH installation and configuration requirements

### DIFF
--- a/collector/src/detect.ts
+++ b/collector/src/detect.ts
@@ -193,14 +193,17 @@ export function isCordisPackageJson(content: string | null): boolean {
 
 /** 检测 README/SKILL 内容中的"需要配置"信号（具体环境变量名） */
 const CONFIG_KEY_RE =
-  /(?:^|[^A-Za-z])(GITHUB_TOKEN|GH_TOKEN|OPENAI_API_KEY|ANTHROPIC_API_KEY|DEEPSEEK_API_KEY|LLM_API_KEY|API_KEY|CLAUDE_API_KEY|AZURE_OPENAI|AWS_ACCESS_KEY|STRIPE_API_KEY|WEBHOOK_SECRET|SESSION_KEY)(?:[^A-Za-z]|$)/i;
+  /(?:^|[^A-Za-z])(GITHUB_TOKEN|GH_TOKEN|OPENAI_API_KEY|ANTHROPIC_API_KEY|DEEPSEEK_API_KEY|LLM_API_KEY|API[ _-]?KEY|CLAUDE_API_KEY|AZURE_OPENAI|AWS_ACCESS_KEY|STRIPE_API_KEY|WEBHOOK_SECRET|SESSION_KEY)(?:[^A-Za-z]|$)/i;
 
 /** 否定语境（"不需要 API key"等）——命中则先摘除，避免误报 */
 const NEGATION_RE =
-  /(?:不需要|无需|不用|免[^。；\n]{0,10}(?:配置|token|key)|no (?:api ?key|token|config|setup|configuration)|without (?:any )?(?:api ?key|token|config)|no configuration required|zero-?config|works (?:out of the box|without))/i;
+  /(?:不需要|无需|不用|免[^。；\n]{0,10}(?:配置|token|key)|no (?:api ?key|token|config|setup|configuration)|without (?:(?:any|an?) )?(?:api ?key|token|config)|no configuration required|zero-?config|works (?:out of the box|without))/i;
 
 export function detectNeedsConfig(readmeContent: string | null): boolean {
   if (!readmeContent) return false;
-  const text = readmeContent.replace(NEGATION_RE, " ");
-  return CONFIG_KEY_RE.test(text);
+  // Check clauses independently: a key-free installer must not hide a key
+  // required by another feature, and negated key mentions are not requirements.
+  return readmeContent.split(/[。；;\n.!?！？]|\bbut\b|\bhowever\b|但是|但/i).some(clause =>
+    CONFIG_KEY_RE.test(clause) && !NEGATION_RE.test(clause)
+  );
 }

--- a/collector/src/scoring.ts
+++ b/collector/src/scoring.ts
@@ -12,6 +12,7 @@
  */
 
 import type { PracticalScore, PracticalScoreBreakdown } from "@dsh-market/schema";
+import { parseInstallCommands } from "./install-parse.js";
 
 export interface ScoreInput {
   stars: number;
@@ -125,7 +126,10 @@ export function scoreEase(readmeContent: string | null, needsConfig: boolean): n
   let s = 0;
   const text = readmeContent ?? "";
   // 有明确安装命令
-  if (/(git clone|pnpm add|npm install -g|npx skills add|npm i -g|pip install)/i.test(text)) {
+  const hasDshInstall = parseInstallCommands(text).commands.some(command =>
+    /^dsh\s+plugin(?:\s+--profile\s+\S+)?\s+(?:add|i)\s+\S/i.test(command)
+  );
+  if (hasDshInstall || /(git clone|pnpm add|npm install -g|npx skills add|npm i -g|pip install)/i.test(text)) {
     s += 35;
   } else if (/(install|安装)/i.test(text)) {
     s += 15;
@@ -133,7 +137,7 @@ export function scoreEase(readmeContent: string | null, needsConfig: boolean): n
   // 无需额外配置
   if (!needsConfig) s += 35;
   // 有结构说明（README 顶部有徽章/描述）
-  if (/^#\s+.+/m.test(text) && text.length > 100) s += 30;
+  if ((/^#\s+.+/m.test(text) || /<h1\b[^>]*>[^<]*\S[\s\S]*?<\/h1>/i.test(text)) && text.length > 100) s += 30;
 
   return Math.round(clip(s));
 }

--- a/collector/test/scoring.test.ts
+++ b/collector/test/scoring.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { scoreEase } from "../src/scoring.js";
+import { detectNeedsConfig } from "../src/detect.js";
+
+const description = "A documented plugin with local workspaces and reproducible installation. ".repeat(3);
+function readme(command: string, heading = "# Example") {
+  return `${heading}\n${description}\n## Installation\n\`\`\`sh\n${command}\n\`\`\`\n`;
+}
+describe("documented installation scoring", () => {
+  it.each([
+    "dsh plugin --profile web add -w example-plugin@1.0.0",
+    "dsh plugin --profile web add https://example.com/plugin.tgz",
+    "dsh plugin add github:author/plugin",
+  ])("recognizes official DSH installation: %s", command => {
+    expect(scoreEase(readme(command), false)).toBe(100);
+    expect(scoreEase(readme(command), true)).toBe(65);
+  });
+  it("recognizes an HTML title without requiring a Markdown duplicate", () => {
+    expect(scoreEase(readme("dsh plugin add example-plugin", '<h1 align="center">Example</h1>'), false)).toBe(100);
+  });
+  it("does not treat a removal command as installation", () => {
+    expect(scoreEase(readme("dsh plugin --profile web remove example-plugin"), false)).toBe(80);
+  });
+});
+describe("model configuration requirements", () => {
+  it.each(["填写模型名、接口地址和 API Key", "Set OPENAI_API_KEY before generating", "Enter your API key in Settings"])("recognizes %s", text => {
+    expect(detectNeedsConfig(text)).toBe(true);
+  });
+  it.each(["无需 API Key。", "No API key required.", "Without an API key", "不需要 OPENAI_API_KEY"])("ignores negated key mentions: %s", text => {
+    expect(detectNeedsConfig(text)).toBe(false);
+  });
+  it("keeps requirements when another step is key-free", () => {
+    expect(detectNeedsConfig("安装无需 API Key；生成需要配置 API Key。")).toBe(true);
+    expect(detectNeedsConfig("No API key for installation, but provide an API key for generation.")).toBe(true);
+  });
+});


### PR DESCRIPTION
Official `dsh plugin --profile web add -w …` commands currently miss the explicit-installation score, and an HTML `<h1>` misses the title signal. Recognize both without changing score weights. Detect a documented UI “API Key” requirement as configuration, while ignoring negated mentions within their own clauses.

Validation: `npm test -w collector` — 97 tests passed, including 13 new scoring/configuration cases. This is a general detection fix; no repository-specific score overrides or stored catalog edits.

Related: #137.
